### PR TITLE
Implement Chapter 17: Add bcrypt password hashing for secure authenti…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "node-mysql",
       "version": "0.0.0",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "cookie-parser": "~1.4.4",
         "cookie-session": "^2.1.1",
         "debug": "~2.6.9",
@@ -49,6 +50,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/bignumber.js": {
@@ -715,6 +730,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "cookie-parser": "~1.4.4",
     "cookie-session": "^2.1.1",
     "debug": "~2.6.9",

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const knex = require('../db/knex');
+const bcrypt = require("bcrypt");
 
 router.get('/', function(req, res, next) {
   const userId = req.session.userid;
@@ -16,18 +17,23 @@ router.post('/', function(req, res, next) {
   
   knex("users").where({
     name: username,
-    password: password,
   }).select("*")
-    .then((results) => {
+    .then(async (results) => {
       if (results.length === 0) {
         res.render("signin", {
           title: "Sign in",
           isAuth: isAuth,
           errorMessage: ["ユーザが見つかりません"],
         });
-      } else {
+      } else if (await bcrypt.compare(password, results[0].password)) {
         req.session.userid = results[0].id;
         res.redirect('/');
+      } else {
+        res.render("signin", {
+          title: "Sign in",
+          isAuth: isAuth,
+          errorMessage: ["ユーザが見つかりません"],
+        });
       }
     })
     .catch(function(err) {

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const knex = require('../db/knex');
+const bcrypt = require("bcrypt");
 
 router.get('/', function(req, res, next) {
   const userId = req.session.userid;
@@ -16,7 +17,7 @@ router.post('/', function(req, res, next) {
   const isAuth = Boolean(userId);
   
   knex("users").where({name: username}).select("*")
-    .then(function(result) {
+    .then(async function(result) {
       if (result.length !== 0) {
         res.render("signup", {
           title: "Sign up",
@@ -24,7 +25,8 @@ router.post('/', function(req, res, next) {
           errorMessage: ["このユーザ名は既に使われています"],
         });
       } else if (password === repassword) {
-        knex("users").insert({name: username, password: password})
+        const hashedPassword = await bcrypt.hash(password, 10);
+        knex("users").insert({name: username, password: hashedPassword})
           .then(function(result) {
             req.session.userid = result[0];
             res.redirect("/");


### PR DESCRIPTION
…cation

- Install bcrypt module for password hashing functionality
- Update signup.js to hash passwords before database storage using bcrypt.hash() with salt rounds of 10
- Implement async/await pattern to handle bcrypt Promise-based operations
- Update signin.js to compare passwords with bcrypt.compare() instead of plain text matching
- Remove password from database query conditions (query by username only)
- Add secure password storage and authentication flow

Following Zenn tutorial: https://zenn.dev/wkb/books/node-tutorial/viewer/todo_09

Link to Devin run: https://app.devin.ai/sessions/6fe83b3111674ff4bcc92f58b99384ac
Requested by: @ToruKurahashi